### PR TITLE
센서에 따른 반응 콘솔창에 표시 되도록 수정

### DIFF
--- a/src/main/java/spring/designpatterns/dom/observer/CarSensor_De/CarSensor.java
+++ b/src/main/java/spring/designpatterns/dom/observer/CarSensor_De/CarSensor.java
@@ -29,7 +29,6 @@ public class CarSensor implements DomSubject{
         this.distance = distance;
         measurementsChanged();
     }
-
     @Override
     public void notifyObservers() {
         for (DomObserver observer : observers) {

--- a/src/main/java/spring/designpatterns/dom/observer/CarSensor_De/Road.java
+++ b/src/main/java/spring/designpatterns/dom/observer/CarSensor_De/Road.java
@@ -3,6 +3,7 @@ package spring.designpatterns.dom.observer.CarSensor_De;
 import java.util.Scanner;
 
 public class Road {
+
     public static void main(String[] args) {
         CarSensor sensor = new CarSensor();
         DomCar domCar = new DomCar();
@@ -16,6 +17,7 @@ public class Road {
             sensor.setMeasurement(distance);
             if (distance < 10) break;
         }
+
         System.out.println("쿵 푸쉬쉬~");
         System.out.println("연기가 피어오른다..");
     }

--- a/src/main/java/spring/designpatterns/dom/observer/CarSensor_Inde/Road.java
+++ b/src/main/java/spring/designpatterns/dom/observer/CarSensor_Inde/Road.java
@@ -5,9 +5,14 @@ import java.util.Scanner;
 public class Road {
     public static void main(String[] args) {
         CarSensor sensor = new CarSensor();
+
+        DomCarBreak carBreak = new DomCarBreak();
+        DomCarSound carSound = new DomCarSound();
         DomCar domCar = new DomCar();
 
         sensor.addObserver(domCar);
+        sensor.addObserver(carSound);
+        sensor.addObserver(carBreak);
 
         Scanner sc = new Scanner(System.in);
 


### PR DESCRIPTION
[수정]
: Independant 자동차 센서 Road에서 sound, break 센서에 추가하여 콘솔창에 거리에 따른 반응 표시되도록 수정

[문제]
: 옵저버에 sound, break를 등록하지 않아서 발생한 문제

[해결]
: 옵저버에 두 기능들을 추가함.

[이미지]
![image](https://github.com/user-attachments/assets/e6c23920-f7ec-40d6-b128-cf92ee202fe3)
